### PR TITLE
fix: use go-ipfs instead of go-ipfs-dep

### DIFF
--- a/src/implementations.json
+++ b/src/implementations.json
@@ -3,6 +3,6 @@
     "moduleName": "ipfs"
   },
   "go": {
-    "moduleName": "go-ipfs-dep"
+    "moduleName": "go-ipfs"
   }
 }

--- a/src/lib/use/index.js
+++ b/src/lib/use/index.js
@@ -18,7 +18,7 @@ const ImplsConf = {
   },
   go: {
     moduleName: Implementations.go.moduleName,
-    binPath: Path.join('node_modules', 'go-ipfs-dep', 'go-ipfs', 'ipfs'),
+    binPath: Path.join('node_modules', 'go-ipfs', 'go-ipfs', 'ipfs'),
     configure: false,
     update: false
   }


### PR DESCRIPTION
go-ipfs-dep is deprecated and at some point will stop receiving updates, so switch out for go-ipfs, a drop-in replacement.