### PR TITLE
fix: read package up from __dirname, not cwd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "iim",
       "version": "0.7.0",
-      "license": "MIT",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "debug": "^4.1.1",
@@ -15,7 +15,6 @@
         "explain-error": "^1.0.4",
         "npm": "^6.0.0",
         "ora": "^7.0.1",
-        "package-up": "^5.0.0",
         "read-package-up": "^11.0.0",
         "semver": "^7.3.2",
         "sinon-ts": "^2.0.0"
@@ -21009,20 +21008,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/package-up/-/package-up-5.0.0.tgz",
-      "integrity": "sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==",
-      "dependencies": {
-        "find-up-simple": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import Path from 'node:path'
+import Url from 'node:url'
 import { readPackageUp } from 'read-package-up'
 
 export default {
@@ -6,7 +8,7 @@ export default {
   help: '',
   options: {},
   run: async () => {
-    const result = await readPackageUp()
+    const result = await readPackageUp({ cwd: Path.dirname(Url.fileURLToPath(import.meta.url)) })
     console.info(result?.packageJson.version)
   }
 }

--- a/src/default-paths.ts
+++ b/src/default-paths.ts
@@ -1,8 +1,9 @@
 import Os from 'node:os'
 import Path from 'node:path'
+import Url from 'node:url'
 import { readPackageUp } from 'read-package-up'
 
-const result = await readPackageUp()
+const result = await readPackageUp({ cwd: Path.dirname(Url.fileURLToPath(import.meta.url)) })
 
 if (result == null) {
   throw new Error('Could not read package.json')

--- a/src/lib/info.ts
+++ b/src/lib/info.ts
@@ -1,6 +1,7 @@
 import Fs from 'node:fs/promises'
 import Os from 'node:os'
 import Path from 'node:path'
+import Url from 'node:url'
 // @ts-expect-error no types
 import explain from 'explain-error'
 import { readPackageUp } from 'read-package-up'
@@ -36,7 +37,7 @@ export default async (ctx: Context, binLinkPath: string, installPath: string): P
     .split(Path.sep)[1]
     .split('@')
 
-  const result = await readPackageUp()
+  const result = await readPackageUp({ cwd: Path.dirname(Url.fileURLToPath(import.meta.url)) })
 
   if (result == null) {
     throw new Error('Could not read package.json')


### PR DESCRIPTION
Fixes using the global binary outside of the repo directory...

```
$ iim use kubo
file:///opt/homebrew/lib/node_modules/iim/dist/src/default-paths.js:6
    throw new Error('Could not read package.json');
          ^

Error: Could not read package.json
    at file:///opt/homebrew/lib/node_modules/iim/dist/src/default-paths.js:6:11

Node.js v20.9.0
```

resolves https://github.com/alanshaw/iim/issues/31