### PR TITLE
fix: allow using deprecated versions

### DIFF
--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -27,6 +27,10 @@ const options: Record<string, ParseArgsOptionConfig> = {
   pre: {
     short: 'p',
     type: 'boolean'
+  },
+  deprecated: {
+    short: 'd',
+    type: 'boolean'
   }
 }
 
@@ -34,12 +38,12 @@ export default {
   aliases: ['u'],
   help,
   options,
-  run: async (positionals: string[], options: { pre: boolean }) => {
+  run: async (positionals: string[], options: { pre: boolean, deprecated: boolean }) => {
     const [implName, versionRange] = positionals
 
     const spinner = ora()
     const npm = new Npm()
-    await use({ npm, spinner }, implName, versionRange, options.pre, binPath, installPath, homePath, currentBinLinkPath)
+    await use({ npm, spinner }, implName, versionRange, options.pre, options.deprecated, binPath, installPath, homePath, currentBinLinkPath)
 
     console.log('🚀 IPFS is ready to use')
   }

--- a/src/lib/npm/index.ts
+++ b/src/lib/npm/index.ts
@@ -52,11 +52,13 @@ export default class NpmLib {
     return versions
   }
 
-  async rangeToVersion (mod: string, range: string, includePre: boolean): Promise<string> {
-    const allVers = await this.getVersions(mod)
+  async rangeToVersion (mod: string, range: string, includePre: boolean, includeDeprecated: boolean): Promise<string> {
+    const allVers = await this.getVersions(mod, {
+      deprecated: includeDeprecated
+    })
 
     if (allVers.length === 0) {
-      throw new Error(`${mod} has no versions to select from`)
+      throw new Error(`${mod} has no versions to select from. Some may be deprecated, pass --deprecated as a flag to enabled their use`)
     }
 
     let rangeVers = includePre

--- a/src/lib/use/index.ts
+++ b/src/lib/use/index.ts
@@ -16,6 +16,7 @@ export default async function use (
   implName: string,
   versionRange: string,
   includePre: boolean,
+  includeDeprecated: boolean,
   binPath: string,
   installPath: string,
   homePath: string,
@@ -36,7 +37,7 @@ export default async function use (
     { npm, spinner },
     implementations[implName].moduleName,
     versionRange,
-    { moduleTitle: `${implName}-ipfs`, includePre }
+    { moduleTitle: `${implName}-ipfs`, includePre, includeDeprecated }
   )
 
   const implInstallPath = Path.join(installPath, `${implName}-ipfs@${version}`)

--- a/src/lib/use/select-version.ts
+++ b/src/lib/use/select-version.ts
@@ -3,6 +3,7 @@ import type { Context } from '../../bin'
 
 export interface SelectVersionOptions {
   includePre: boolean
+  includeDeprecated: boolean
   moduleTitle: string
 }
 
@@ -12,7 +13,7 @@ export default async function selectVersion (ctx: Required<Context>, mod: string
 
   spinner.start(`finding ${options.moduleTitle} versions`)
   try {
-    version = await npm.rangeToVersion(mod, version, options.includePre)
+    version = await npm.rangeToVersion(mod, version, options.includePre, options.includeDeprecated)
   } catch (err) {
     spinner.fail(`failed to find ${options.moduleTitle} versions`)
     throw err


### PR DESCRIPTION
Adds a `--deprecated`/`-d` flag to `iim use` which includes deprecated versions in the list of versions eligible to install.

Fixes #33